### PR TITLE
route rate limiter: initial implementation

### DIFF
--- a/cmd/guardian-cli/main.go
+++ b/cmd/guardian-cli/main.go
@@ -64,7 +64,7 @@ func main() {
 	redisOpts := &redis.Options{Addr: *redisAddress}
 	redis := redis.NewClient(redisOpts)
 	logger := logrus.StandardLogger()
-	redisConfStore := guardian.NewRedisConfStore(redis, []net.IPNet{}, []net.IPNet{}, guardian.Limit{}, false, logger)
+	redisConfStore := guardian.NewRedisConfStore(redis, []net.IPNet{}, []net.IPNet{}, guardian.Limit{}, false, logger, nil)
 
 	level, err := logrus.ParseLevel(*logLevel)
 	if err != nil {

--- a/e2e/docker-compose-sync.yml
+++ b/e2e/docker-compose-sync.yml
@@ -1,8 +1,8 @@
 version: '3'
 services:
-  envoy: 
+  envoy:
     build: envoy/.
-    ports: 
+    ports:
     - "8080:8080"
   guardian:
     build: ../.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -134,7 +134,7 @@ func TestRouteRateLimit(t *testing.T) {
 	}
 
 	for _, routeRateLimit := range rrlConfig.RouteRatelimits {
-		for i := uint64(0); i < routeRateLimit.Limit.Count + 25; i++ {
+		for i := uint64(0); i < routeRateLimit.Limit.Count + 5; i++ {
 			if len(os.Getenv("SYNC")) == 0 {
 				time.Sleep(100 * time.Millisecond) // helps prevents races due asynchronous rate limiting
 			}

--- a/pkg/guardian/blacklist.go
+++ b/pkg/guardian/blacklist.go
@@ -60,7 +60,6 @@ func (w *IPBlacklister) IsBlacklisted(context context.Context, req Request) (boo
 	w.logger.Debug("Getting blacklist")
 	blacklist := w.provider.GetBlacklist()
 	w.logger.Debugf("Got blacklist with length %d", len(blacklist))
-	w.reporter.CurrentBlacklist(blacklist)
 
 	for _, cidr := range blacklist {
 		if cidr.Contains(ip) {

--- a/pkg/guardian/blacklist.go
+++ b/pkg/guardian/blacklist.go
@@ -67,7 +67,6 @@ func (w *IPBlacklister) IsBlacklisted(context context.Context, req Request) (boo
 			blacklisted = true
 			return true, nil
 		}
-		w.logger.Debugf("CIDR %v does not contain %v of blacklist", cidr.String(), ip)
 	}
 
 	w.logger.Debugf("%v NOT FOUND in blacklist", ip)

--- a/pkg/guardian/ipratelimit.go
+++ b/pkg/guardian/ipratelimit.go
@@ -1,5 +1,53 @@
 package guardian
 
+import (
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+// This file contains the implementation of an IP Rate Limiter.
+// It enforces a limit that is applied upon every single request.
+// This is achieved by writing custom implementations of the KeyFunc and LimitProvider that the GenericRateLimiter
+// struct depends on.
+
+// GlobalLimitProvider implements the LimitProvider interface.
+type GlobalLimitProvider struct {
+	*RedisConfStore
+}
+
+// GetLimit gets the global limit applied to all requests.
+func (glp *GlobalLimitProvider) GetLimit(_ Request) Limit {
+	glp.conf.RLock()
+	defer glp.conf.RUnlock()
+
+	return glp.conf.limit
+}
+
+// NewGlobalLimitProvider returns an implementation of a LimitProvider intended to provide limits for all requests from
+// a given client IP.
+func NewGlobalLimitProvider(rcs *RedisConfStore) *GlobalLimitProvider {
+	return &GlobalLimitProvider{rcs}
+}
+
+// RouteRateLimiterKeyFunc provides a key unique to a particular client IP.
 func IPRateLimiterKeyFunc(req Request) string {
 	return req.RemoteAddress
+}
+
+// ReportRateLimitHandled reports that a rate limit request was handled and provides some metadata.
+func ReportRateLimitHandled(mr MetricReporter) RateLimitHook {
+	return func(req Request, limit Limit, rateLimited bool, dur time.Duration, rlErr error) {
+		mr.HandledRatelimit(req, rateLimited, rlErr != nil, dur)
+	}
+}
+
+// NewIPRateLimiter returns a rate limiter that enforces a limit upon all requests from each client IP.
+func NewIPRateLimiter(rcf *RedisConfStore, l logrus.FieldLogger, mr MetricReporter, c Counter) *GenericRateLimiter {
+	return &GenericRateLimiter{
+		KeyFunc:            IPRateLimiterKeyFunc,
+		LimitProvider:      NewGlobalLimitProvider(rcf),
+		Counter:            c,
+		Logger:             l,
+		OnRateLimitHandled: []RateLimitHook{ReportRateLimitHandled(mr)},
+	}
 }

--- a/pkg/guardian/ipratelimit_test.go
+++ b/pkg/guardian/ipratelimit_test.go
@@ -1,0 +1,44 @@
+package guardian
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGlobalLimitProvider(t *testing.T) {
+	expectedLimit := Limit{Count: 2, Duration: time.Minute, Enabled: true}
+
+	cs, s := newTestConfStoreWithDefaults(t, nil, nil, expectedLimit, false)
+	defer s.Close()
+
+	tests := []struct {
+		name string
+		req  Request
+		want Limit
+	}{
+		{
+			name: "empty request",
+			req:  Request{},
+			want: expectedLimit,
+		}, {
+			name: "populated request",
+			req: Request{
+				RemoteAddress: "10.0.0.1",
+				Authority:     "foo.bar.com",
+				Method:        "GET",
+				Path:          "/",
+				Headers:       nil,
+			},
+			want: expectedLimit,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			glp := NewGlobalLimitProvider(cs)
+			if got := glp.GetLimit(tt.req); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLimit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/guardian/metrics_test.go
+++ b/pkg/guardian/metrics_test.go
@@ -35,7 +35,8 @@ func TestDatadogReportSetsDefaultTags(t *testing.T) {
 	reporter.HandledRatelimit(req, true, false, time.Second)
 	reporter.RedisCounterIncr(time.Second, false)
 	reporter.RedisCounterPruned(time.Second, 100, 20)
-	reporter.CurrentLimit(Limit{})
+	reporter.CurrentGlobalLimit(Limit{})
+	reporter.CurrentRouteLimit(req.Path, Limit{})
 	reporter.CurrentWhitelist([]net.IPNet{})
 	reporter.CurrentReportOnlyMode(false)
 

--- a/pkg/guardian/ratelimit.go
+++ b/pkg/guardian/ratelimit.go
@@ -22,46 +22,54 @@ func (l Limit) String() string {
 	return fmt.Sprintf("Limit(%d per %v, enabled: %v)", l.Count, l.Duration, l.Enabled)
 }
 
-// LimitProvider provides the current limit settings
+// LimitProvider provides the current limit settings based off a given request.
 type LimitProvider interface {
-	// GetLimit returns the current limit settings
-	GetLimit() Limit
+	// GetLimit can determine what the limit is based off the data provided in the request.
+	// It is up to the limit provider to determine the characteristics of the requests it cares about.
+	// For example, a simple IP rate limiter could ignore the request entirely.
+	GetLimit(req Request) Limit
 }
 
 // Counter is a data store capable of incrementing and expiring the count of a key
 type Counter interface {
 
-	// Incr increments key by count and sets the expiration to expireIn from now. The result of the incr, whether to force block,
+	// Incr incrementsHandledRatelimit key by count and sets the expiration to expireIn from now. The result of the incr, whether to force block,
 	// and an error is returned
 	Incr(context context.Context, key string, incryBy uint, maxBeforeBlock uint64, expireIn time.Duration) (uint64, bool, error)
 }
 
-// GenericRateLimiter is a rate limiter that uses a function to decide the counter key for rate limiting
+type RateLimitHook func(req Request, limit Limit, rateLimited bool, dur time.Duration, err error)
+
+// GenericRateLimiter is a multipurpose rate limiter. It allows users to customize how the rate limiter behaves through 2 main mechanisms.
+// 1. A KeyFunc that determines the key that wil be used for incrementing.
+// 2. A LimitProvider that determines how the limit will be calculated.
 type GenericRateLimiter struct {
-	KeyFunc  func(req Request) string
-	Conf     LimitProvider
-	Counter  Counter
-	Logger   logrus.FieldLogger
-	Reporter MetricReporter
+	KeyFunc          func(req Request) string
+	LimitProvider    LimitProvider
+	Counter          Counter
+	Logger           logrus.FieldLogger
+	OnRateLimitHandled []RateLimitHook
 }
 
 // Limit limits a request if request exceeds rate limit
 func (rl *GenericRateLimiter) Limit(context context.Context, request Request) (bool, uint32, error) {
-	if rl.KeyFunc == nil || rl.Conf == nil || rl.Counter == nil || rl.Logger == nil || rl.Reporter == nil {
+	if rl.KeyFunc == nil || rl.LimitProvider == nil || rl.Counter == nil || rl.Logger == nil {
 		return false, math.MaxUint32, nil
 	}
 
 	start := time.Now().UTC()
 	ratelimited := false
+	var limit Limit
 	var err error
 	defer func() {
-		rl.Reporter.HandledRatelimit(request, ratelimited, err != nil, time.Since(start))
+		for _, hook := range rl.OnRateLimitHandled {
+			hook(request, limit, ratelimited, time.Since(start), err)
+		}
+
 	}()
 
-	limit := rl.Conf.GetLimit()
+	limit = rl.LimitProvider.GetLimit(request)
 	rl.Logger.Debugf("fetched limit %v", limit)
-	rl.Reporter.CurrentLimit(limit)
-
 	if !limit.Enabled {
 		rl.Logger.Debugf("limit not enabled for request %v, allowing", request)
 		return false, math.MaxUint32, nil
@@ -85,7 +93,7 @@ func (rl *GenericRateLimiter) Limit(context context.Context, request Request) (b
 
 	remaining64 := limit.Count - currCount
 	remaining32 := uint32(remaining64)
-	if uint64(remaining32) != remaining64 { // if we lose some signifcant bits, convert it to max of uint32
+	if uint64(remaining32) != remaining64 { // if we lose some significant bits, convert it to max of uint32
 		rl.Logger.Errorf("overflow detected, setting to max uint32: remaining64 %v remaining32", remaining64, remaining32)
 		remaining32 = math.MaxUint32
 	}

--- a/pkg/guardian/ratelimit.go
+++ b/pkg/guardian/ratelimit.go
@@ -69,7 +69,7 @@ func (rl *GenericRateLimiter) Limit(context context.Context, request Request) (b
 	}()
 
 	limit = rl.LimitProvider.GetLimit(request)
-	rl.Logger.Debugf("fetched limit %v", limit)
+	rl.Logger.Debugf("fetched limit %v for request %v", limit, request.Path)
 	if !limit.Enabled {
 		rl.Logger.Debugf("limit not enabled for request %v, allowing", request)
 		return false, math.MaxUint32, nil

--- a/pkg/guardian/ratelimit.go
+++ b/pkg/guardian/ratelimit.go
@@ -33,7 +33,7 @@ type LimitProvider interface {
 // Counter is a data store capable of incrementing and expiring the count of a key
 type Counter interface {
 
-	// Incr incrementsHandledRatelimit key by count and sets the expiration to expireIn from now. The result of the incr, whether to force block,
+	// Incr increments key by count and sets the expiration to expireIn from now. The result of the incr, whether to force block,
 	// and an error is returned
 	Incr(context context.Context, key string, incryBy uint, maxBeforeBlock uint64, expireIn time.Duration) (uint64, bool, error)
 }

--- a/pkg/guardian/redis_conf_store.go
+++ b/pkg/guardian/redis_conf_store.go
@@ -252,6 +252,13 @@ func (rs *RedisConfStore) FetchRouteRateLimits() (map[url.URL]Limit, error) {
 	return res, nil
 }
 
+func (rs *RedisConfStore) GetLimit() Limit {
+	rs.conf.RLock()
+	defer rs.conf.RUnlock()
+
+	return rs.conf.limit
+}
+
 func (rs *RedisConfStore) FetchLimit() (Limit, error) {
 	c := rs.pipelinedFetchConf()
 	if c.limitCount == nil || c.limitDuration == nil || c.limitEnabled == nil {

--- a/pkg/guardian/redis_conf_store_test.go
+++ b/pkg/guardian/redis_conf_store_test.go
@@ -22,7 +22,7 @@ func newTestConfStoreWithDefaults(t *testing.T, defaultWhitelist []net.IPNet, de
 	}
 
 	redis := redis.NewClient(&redis.Options{Addr: s.Addr()})
-	return NewRedisConfStore(redis, defaultWhitelist, defaultBlacklist, defaultLimit, defaultReportOnly, TestingLogger), s
+	return NewRedisConfStore(redis, defaultWhitelist, defaultBlacklist, defaultLimit, defaultReportOnly, TestingLogger, NullReporter{}), s
 }
 
 func TestConfStoreReturnsDefaults(t *testing.T) {
@@ -36,7 +36,6 @@ func TestConfStoreReturnsDefaults(t *testing.T) {
 
 	gotWhitelist := c.GetWhitelist()
 	gotBlacklist := c.GetBlacklist()
-	gotLimit := c.GetLimit()
 	gotReportOnly := c.GetReportOnly()
 
 	if !cmp.Equal(gotWhitelist, expectedWhitelist) {
@@ -45,10 +44,6 @@ func TestConfStoreReturnsDefaults(t *testing.T) {
 
 	if !cmp.Equal(gotBlacklist, expectedBlacklist) {
 		t.Errorf("expected: %v received: %v", expectedWhitelist, gotWhitelist)
-	}
-
-	if gotLimit != expectedLimit {
-		t.Errorf("expected: %v received: %v", expectedLimit, gotLimit)
 	}
 
 	if gotReportOnly != expectedReportOnly {
@@ -183,7 +178,6 @@ func TestConfStoreUpdateCacheConf(t *testing.T) {
 
 	gotWhitelist := c.GetWhitelist()
 	gotBlacklist := c.GetBlacklist()
-	gotLimit := c.GetLimit()
 	gotReportOnly := c.GetReportOnly()
 
 	if !cmp.Equal(gotWhitelist, expectedWhitelist) {
@@ -192,10 +186,6 @@ func TestConfStoreUpdateCacheConf(t *testing.T) {
 
 	if !cmp.Equal(gotBlacklist, expectedBlacklist) {
 		t.Errorf("expected: %v received: %v", expectedBlacklist, gotBlacklist)
-	}
-
-	if gotLimit != expectedLimit {
-		t.Errorf("expected: %v received: %v", expectedLimit, gotLimit)
 	}
 
 	if gotReportOnly != expectedReportOnly {
@@ -240,7 +230,6 @@ func TestConfStoreRunUpdatesCache(t *testing.T) {
 
 	gotWhitelist := c.GetWhitelist()
 	gotBlacklist := c.GetBlacklist()
-	gotLimit := c.GetLimit()
 	gotReportOnly := c.GetReportOnly()
 
 	if !cmp.Equal(gotWhitelist, expectedWhitelist) {
@@ -249,10 +238,6 @@ func TestConfStoreRunUpdatesCache(t *testing.T) {
 
 	if !cmp.Equal(gotBlacklist, expectedBlacklist) {
 		t.Errorf("expected: %v received: %v", expectedWhitelist, gotWhitelist)
-	}
-
-	if gotLimit != expectedLimit {
-		t.Errorf("expected: %v received: %v", expectedLimit, gotLimit)
 	}
 
 	if gotReportOnly != expectedReportOnly {

--- a/pkg/guardian/redis_conf_store_test.go
+++ b/pkg/guardian/redis_conf_store_test.go
@@ -36,6 +36,7 @@ func TestConfStoreReturnsDefaults(t *testing.T) {
 
 	gotWhitelist := c.GetWhitelist()
 	gotBlacklist := c.GetBlacklist()
+	gotLimit := c.GetLimit()
 	gotReportOnly := c.GetReportOnly()
 
 	if !cmp.Equal(gotWhitelist, expectedWhitelist) {
@@ -44,6 +45,10 @@ func TestConfStoreReturnsDefaults(t *testing.T) {
 
 	if !cmp.Equal(gotBlacklist, expectedBlacklist) {
 		t.Errorf("expected: %v received: %v", expectedWhitelist, gotWhitelist)
+	}
+
+	if gotLimit != expectedLimit {
+		t.Errorf("expected: %v received: %v", expectedLimit, gotLimit)
 	}
 
 	if gotReportOnly != expectedReportOnly {
@@ -178,6 +183,7 @@ func TestConfStoreUpdateCacheConf(t *testing.T) {
 
 	gotWhitelist := c.GetWhitelist()
 	gotBlacklist := c.GetBlacklist()
+	gotLimit := c.GetLimit()
 	gotReportOnly := c.GetReportOnly()
 
 	if !cmp.Equal(gotWhitelist, expectedWhitelist) {
@@ -186,6 +192,10 @@ func TestConfStoreUpdateCacheConf(t *testing.T) {
 
 	if !cmp.Equal(gotBlacklist, expectedBlacklist) {
 		t.Errorf("expected: %v received: %v", expectedBlacklist, gotBlacklist)
+	}
+
+	if gotLimit != expectedLimit {
+		t.Errorf("expected: %v received: %v", expectedLimit, gotLimit)
 	}
 
 	if gotReportOnly != expectedReportOnly {
@@ -230,6 +240,7 @@ func TestConfStoreRunUpdatesCache(t *testing.T) {
 
 	gotWhitelist := c.GetWhitelist()
 	gotBlacklist := c.GetBlacklist()
+	gotLimit := c.GetLimit()
 	gotReportOnly := c.GetReportOnly()
 
 	if !cmp.Equal(gotWhitelist, expectedWhitelist) {
@@ -238,6 +249,10 @@ func TestConfStoreRunUpdatesCache(t *testing.T) {
 
 	if !cmp.Equal(gotBlacklist, expectedBlacklist) {
 		t.Errorf("expected: %v received: %v", expectedWhitelist, gotWhitelist)
+	}
+
+	if gotLimit != expectedLimit {
+		t.Errorf("expected: %v received: %v", expectedLimit, gotLimit)
 	}
 
 	if gotReportOnly != expectedReportOnly {

--- a/pkg/guardian/routeratelimit.go
+++ b/pkg/guardian/routeratelimit.go
@@ -1,5 +1,62 @@
 package guardian
 
+import (
+	"github.com/sirupsen/logrus"
+	"net/url"
+	"time"
+)
+
+// This file contains the implementation of a Route Rate Limiter.
+// This is achieved by writing custom implementations of the KeyFunc and LimitProvider that the GenericRateLimiter
+// struct depends upon.
+
+// RouteLimitProvider implements the LimitProvider interface.
+type RouteLimitProvider struct {
+	*RedisConfStore
+}
+
+// GetLimit gets the limit for a particular request's path.
+func (rlp *RouteLimitProvider) GetLimit(req Request) Limit {
+	reqUrl, err := url.Parse(req.Path)
+	if err != nil || reqUrl == nil {
+		rlp.logger.Warnf("unable to parse url from request: %v", err)
+		return Limit{Enabled: false}
+	}
+
+	rlp.conf.RLock()
+	defer rlp.conf.RUnlock()
+	return rlp.conf.routeRateLimits[*reqUrl]
+}
+
+// NewRouteRateLimitProvider returns an implementation of a LimitProvider intended to provide limits based off a
+// a request's path and a client's IP address.
+func NewRouteRateLimitProvider(rcs *RedisConfStore) *RouteLimitProvider {
+	return &RouteLimitProvider{rcs}
+}
+
+// RouteRateLimiterKeyFunc provides a key unique to a particular client IP and request path.
 func RouteRateLimiterKeyFunc(req Request) string {
 	return req.RemoteAddress + ":" + req.Path
+}
+
+func OnRouteRateLimitHandled(mr MetricReporter) RateLimitHook {
+	return func(req Request, limit Limit, rateLimited bool, dur time.Duration, rlErr error) {
+		if rateLimited {
+			// Only report the route metadata when a request has been rate limited. This allows the cardinality of these
+			// custom metrics to be bounded by the number of enabled route rate limits.
+			mr.HandledRatelimitWithRoute(req, rateLimited, rlErr != nil, dur)
+			return
+		}
+		mr.HandledRatelimit(req, rateLimited, rlErr != nil, dur)
+	}
+}
+
+func NewRouteRateLimiter(rcf *RedisConfStore, l logrus.FieldLogger, mr MetricReporter, c Counter) *GenericRateLimiter {
+	return &GenericRateLimiter{
+		KeyFunc:            RouteRateLimiterKeyFunc,
+		LimitProvider:      NewRouteRateLimitProvider(rcf),
+		Counter:            c,
+		Logger:             l,
+		OnRateLimitHandled: []RateLimitHook{OnRouteRateLimitHandled(mr)},
+	}
 }

--- a/pkg/guardian/routeratelimit_test.go
+++ b/pkg/guardian/routeratelimit_test.go
@@ -42,7 +42,7 @@ func TestRouteLimitProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rlp := NewRouteRateLimitProvider(cs)
+			rlp := NewRouteRateLimitProvider(cs, TestingLogger)
 			if gotLimit := rlp.GetLimit(tt.req); !reflect.DeepEqual(gotLimit, tt.wantLimit) {
 				t.Errorf("GetLimit() = %v, want %v", gotLimit, tt.wantLimit)
 			}
@@ -61,7 +61,7 @@ func TestRouteLimitProviderUpdates(t *testing.T) {
 	cs.SetRouteRateLimits(routeLimits)
 	cs.UpdateCachedConf()
 
-	rlp := NewRouteRateLimitProvider(cs)
+	rlp := NewRouteRateLimitProvider(cs, TestingLogger)
 	gotLimit := rlp.GetLimit(Request{Path: "/foo/bar"})
 	if !reflect.DeepEqual(gotLimit, fooBarRouteLimit) {
 		t.Errorf("GetLimit() = %v, want %v", gotLimit, fooBarRouteLimit)

--- a/pkg/guardian/routeratelimit_test.go
+++ b/pkg/guardian/routeratelimit_test.go
@@ -1,0 +1,80 @@
+package guardian
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRouteLimitProvider(t *testing.T) {
+	fooBarRouteLimit := Limit{Count: 2, Duration: time.Minute, Enabled:  true}
+	route := url.URL{Path: "/foo/bar"}
+	routeLimits := map[url.URL]Limit{route: fooBarRouteLimit}
+	globalLimit := Limit{Count: 2, Duration: time.Minute, Enabled: true}
+	cs, s := newTestConfStoreWithDefaults(t, nil, nil, globalLimit, false)
+	defer s.Close()
+
+	cs.SetRouteRateLimits(routeLimits)
+	cs.UpdateCachedConf()
+
+	tests := []struct {
+		name      string
+		req       Request
+		wantLimit Limit
+	}{
+		{
+			name:      "route with limit",
+			req:       Request{Path: "/foo/bar"},
+			wantLimit: fooBarRouteLimit,
+		},
+		{
+			name:      "sub route without limit",
+			req:       Request{Path: "/foo/bar/baz"},
+			wantLimit: Limit{Enabled: false},
+		},
+		{
+			name:      "route without limit",
+			req:       Request{Path: "/baz"},
+			wantLimit: Limit{Enabled: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rlp := NewRouteRateLimitProvider(cs)
+			if gotLimit := rlp.GetLimit(tt.req); !reflect.DeepEqual(gotLimit, tt.wantLimit) {
+				t.Errorf("GetLimit() = %v, want %v", gotLimit, tt.wantLimit)
+			}
+		})
+	}
+}
+
+func TestRouteLimitProviderUpdates(t *testing.T) {
+	fooBarRouteLimit := Limit{Count: 2, Duration: time.Minute, Enabled:  true}
+	route := url.URL{Path: "/foo/bar"}
+	routeLimits := map[url.URL]Limit{route: fooBarRouteLimit}
+	globalLimit := Limit{Count: 2, Duration: time.Minute, Enabled: true}
+	cs, s := newTestConfStoreWithDefaults(t, nil, nil, globalLimit, false)
+	defer s.Close()
+
+	cs.SetRouteRateLimits(routeLimits)
+	cs.UpdateCachedConf()
+
+	rlp := NewRouteRateLimitProvider(cs)
+	gotLimit := rlp.GetLimit(Request{Path: "/foo/bar"})
+	if !reflect.DeepEqual(gotLimit, fooBarRouteLimit) {
+		t.Errorf("GetLimit() = %v, want %v", gotLimit, fooBarRouteLimit)
+	}
+
+	fooBarRouteLimit = Limit{Count: 43, Duration: time.Minute, Enabled: true}
+
+	newRouteLimits := map[url.URL]Limit{route: fooBarRouteLimit}
+	cs.SetRouteRateLimits(newRouteLimits)
+	cs.UpdateCachedConf()
+
+	gotLimit = rlp.GetLimit(Request{Path: "/foo/bar"})
+	if !reflect.DeepEqual(gotLimit, fooBarRouteLimit) {
+		t.Errorf("GetLimit() = %v, want %v", gotLimit, fooBarRouteLimit)
+	}
+}

--- a/pkg/guardian/server.go
+++ b/pkg/guardian/server.go
@@ -43,7 +43,6 @@ func (s *Server) ShouldRateLimit(ctx context.Context, relreq *ratelimit.RateLimi
 	}
 
 	reportOnly := s.roProvider.GetReportOnly()
-	s.reporter.CurrentReportOnlyMode(reportOnly)
 
 	if block && !reportOnly {
 		resp.OverallCode = ratelimit.RateLimitResponse_OVER_LIMIT

--- a/pkg/guardian/whitelist.go
+++ b/pkg/guardian/whitelist.go
@@ -75,7 +75,6 @@ func (w *IPWhitelister) IsWhitelisted(context context.Context, req Request) (boo
 	w.logger.Debug("Getting whitelist")
 	whitelist := w.provider.GetWhitelist()
 	w.logger.Debugf("Got whitelist with length %d", len(whitelist))
-	w.reporter.CurrentWhitelist(whitelist)
 
 	for _, cidr := range whitelist {
 		if cidr.Contains(ip) {

--- a/pkg/guardian/whitelist.go
+++ b/pkg/guardian/whitelist.go
@@ -82,7 +82,6 @@ func (w *IPWhitelister) IsWhitelisted(context context.Context, req Request) (boo
 			whitelisted = true
 			return true, nil
 		}
-		w.logger.Debugf("CIDR %v does not contain %v of whitelist", cidr.String(), ip)
 	}
 
 	w.logger.Debugf("%v NOT FOUND in whitelist", ip)


### PR DESCRIPTION
This patch allows Guardian to respect route rate limits that are already specified in its configuration store. 

To support this feature utilizing the `GenericRateLimiter` struct, I made the followings changes.

- Modified the `LimitProvider` interface to inspect the request being handled by Guardian. Additionally, I created 2 new implementations of this interface. The `GlobalLimitProvider` and the `RouteLimitProvider` which provide the proper limit value depending upon the request. 
- Removed the direct `Reporter` dependency by the `GenericRateLimiter`. I decided this for a few reasons. For one, I didn't want the `GenericRateLimiter` to have custom logic to support reporting metrics from various different kinds of rate limiters. Also, it seemed that we were reporting global configuration metrics from the `GenericRateLimiter` Limit call directly. Since we now have 2 different `LimitProvider` implementation, the reported metric would have been incorrect in many cases. 
- Removed Configuration reporting from the request hot path. I mainly did this to support the above effort of removing the Reporter dependency in the `GlobalLimitProvider`. Now, the metrics are generated from the configuration store directly, whenever the cache is fetched/updated. 

