### PR TITLE
metrics: fix issue with integer division

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -251,7 +251,7 @@ func TestJails(t *testing.T) {
 		banned := false
 		resetRedis(*redisAddr)
 		applyGuardianConfig(t, *redisAddr, config)
-		for i := uint64(0); i < j.Jail.Limit.Count+5; i++ {
+		for i := uint64(0); i < j.Jail.Limit.Count+1; i++ {
 			if len(os.Getenv("SYNC")) == 0 {
 				time.Sleep(150 * time.Millisecond) // helps prevents races due asynchronous rate limiting
 			}
@@ -276,9 +276,9 @@ func TestJails(t *testing.T) {
 			}
 		}
 		if j.Jail.Limit.Enabled {
-			t.Logf("sleeping for ban_duration: %v to ensure the prisoner is removed", j.Jail.BanDuration)
+			t.Logf("sleeping for ban_duration: %v + 2 seconds to ensure the prisoner is removed", j.Jail.BanDuration)
 			time.Sleep(j.Jail.BanDuration)
-			time.Sleep(j.Jail.Limit.Duration)
+			time.Sleep(2 * time.Second)  // ensure that we sleep for an additional confUpdateInterval so that the configuration is updated
 			res := GET(t, "192.168.1.43", j.Route)
 			if res.StatusCode != 200 {
 				t.Fatalf("prisoner was never removed, received unexpected status code: %d, %v", res.StatusCode, j.Jail)

--- a/pkg/guardian/metrics.go
+++ b/pkg/guardian/metrics.go
@@ -113,7 +113,7 @@ func (d *DataDogReporter) Duration(request Request, blocked bool, errorOccurred 
 		blockedTag := blockedKey + ":" + strconv.FormatBool(blocked)
 		errorTag := errorKey + ":" + strconv.FormatBool(errorOccurred)
 		tags := append([]string{blockedTag, errorTag}, d.defaultTags...)
-		d.client.TimeInMilliseconds(durationMetricName, float64(duration/time.Millisecond), tags, 1)
+		d.client.Timing(durationMetricName, duration, tags, 1)
 	}
 
 	d.enqueue(f)
@@ -124,7 +124,7 @@ func (d *DataDogReporter) HandledWhitelist(request Request, whitelisted bool, er
 		whitelistedTag := whitelistedKey + ":" + strconv.FormatBool(whitelisted)
 		errorTag := errorKey + ":" + strconv.FormatBool(errorOccurred)
 		tags := append([]string{whitelistedTag, errorTag}, d.defaultTags...)
-		d.client.TimeInMilliseconds(reqWhitelistMetricName, float64(duration/time.Millisecond), tags, 1.0)
+		d.client.Timing(reqWhitelistMetricName, duration, tags, 1.0)
 	}
 	d.enqueue(f)
 }
@@ -134,7 +134,7 @@ func (d *DataDogReporter) HandledBlacklist(request Request, blacklisted bool, er
 		blacklistedTag := blacklistedKey + ":" + strconv.FormatBool(blacklisted)
 		errorTag := errorKey + ":" + strconv.FormatBool(errorOccurred)
 		tags := append([]string{blacklistedTag, errorTag}, d.defaultTags...)
-		d.client.TimeInMilliseconds(reqBlacklistMetricName, float64(duration/time.Millisecond), tags, 1.0)
+		d.client.Timing(reqBlacklistMetricName, duration, tags, 1.0)
 	}
 	d.enqueue(f)
 }
@@ -144,7 +144,7 @@ func (d *DataDogReporter) HandledRatelimit(request Request, ratelimited bool, er
 		ratelimitedTag := ratelimitedKey + ":" + strconv.FormatBool(ratelimited)
 		errorTag := errorKey + ":" + strconv.FormatBool(errorOccurred)
 		tags := append([]string{ratelimitedTag, errorTag}, d.defaultTags...)
-		d.client.TimeInMilliseconds(reqRateLimitMetricName, float64(duration/time.Millisecond), tags, 1.0)
+		d.client.Timing(reqRateLimitMetricName, duration, tags, 1.0)
 	}
 	d.enqueue(f)
 }
@@ -155,7 +155,7 @@ func (d *DataDogReporter) HandledRatelimitWithRoute(request Request, ratelimited
 		errorTag := errorKey + ":" + strconv.FormatBool(errorOccurred)
 		routeTag := routeKey + ":" + request.Path
 		tags := append([]string{ratelimitedTag, errorTag, routeTag}, d.defaultTags...)
-		d.client.TimeInMilliseconds(reqRateLimitMetricName, float64(duration/time.Millisecond), tags, 1.0)
+		d.client.Timing(reqRateLimitMetricName, duration, tags, 1.0)
 	}
 	d.enqueue(f)
 }
@@ -171,7 +171,7 @@ func (d *DataDogReporter) HandledJail(request Request, blocked bool, errorOccurr
 		blockedTag := blockedKey + ":" + strconv.FormatBool(blocked)
 		errorTag := errorKey + ":" + strconv.FormatBool(errorOccurred)
 		tags := append(tags, []string{blockedTag, errorTag}...)
-		d.client.TimeInMilliseconds(reqJailMetricName, float64(duration/time.Millisecond), tags, 1.0)
+		d.client.Timing(reqJailMetricName, duration, tags, 1.0)
 	}
 	d.enqueue(f)
 }
@@ -191,7 +191,7 @@ func (d *DataDogReporter) RedisCounterIncr(duration time.Duration, errorOccurred
 	f := func() {
 		errorTag := errorKey + ":" + strconv.FormatBool(errorOccurred)
 		tags := append([]string{errorTag}, d.defaultTags...)
-		d.client.TimeInMilliseconds(redisCounterIncrMetricName, float64(duration/time.Millisecond), tags, 1.0)
+		d.client.Timing(redisCounterIncrMetricName, duration, tags, 1.0)
 	}
 	d.enqueue(f)
 }
@@ -200,7 +200,7 @@ func (d *DataDogReporter) RedisCounterPruned(duration time.Duration, cacheSize f
 	f := func() {
 		d.client.Gauge(redisCounterCacheSizeMetricName, cacheSize, d.defaultTags, 1)
 		d.client.Gauge(redisCounterPrunedMetricName, prunedCounted, d.defaultTags, 1)
-		d.client.TimeInMilliseconds(redisCounterPrunePassMetricName, float64(duration/time.Millisecond), d.defaultTags, 1)
+		d.client.Timing(redisCounterPrunePassMetricName, duration, d.defaultTags, 1)
 	}
 	d.enqueue(f)
 }


### PR DESCRIPTION
The integer division we are doing throughout the DatadogReporter is causing some durations to reported as 0 seconds, if the operation duration is under a millisecond. 

Here is a playground to help display the issue and how using the datadog client's `Timing` function fixes the issue. 

https://play.golang.org/p/Kqye0x56_O4