### PR TITLE
tests: fix e2e tests

### DIFF
--- a/e2e/docker-compose-async.yml
+++ b/e2e/docker-compose-async.yml
@@ -10,11 +10,13 @@ services:
     ports:
     - "3000:3000"
     - "6060:6060"
+    - "4343:4343"
     environment:
       GUARDIAN_FLAG_REDIS_ADDRESS: "redis:6379"
       GUARDIAN_FLAG_LOG_LEVEL: "debug"
       GUARDIAN_FLAG_CONF_UPDATE_INTERVAL: "500ms"
       GUARDIAN_FLAG_SYNCHRONOUS: "false"
+      GUARDIAN_FLAG_INTERNAL_CACHE_SERVER_ADDRESS: "0.0.0.0:4343"
     depends_on:
     - redis
   upstream:

--- a/e2e/docker-compose-sync.yml
+++ b/e2e/docker-compose-sync.yml
@@ -9,11 +9,13 @@ services:
     ports:
     - "3000:3000"
     - "6060:6060"
+    - "4343:4343"
     environment:
       GUARDIAN_FLAG_REDIS_ADDRESS: "redis:6379"
       GUARDIAN_FLAG_LOG_LEVEL: "debug"
       GUARDIAN_FLAG_CONF_UPDATE_INTERVAL: "500ms"
       GUARDIAN_FLAG_SYNCHRONOUS: "true"
+      GUARDIAN_FLAG_INTERNAL_CACHE_SERVER_ADDRESS: "0.0.0.0:4343"
     depends_on:
     - redis
   upstream:

--- a/pkg/guardian/cach_server_test.go
+++ b/pkg/guardian/cach_server_test.go
@@ -1,0 +1,49 @@
+package guardian
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCacheServerDeleteCounters(t *testing.T) {
+	c, s := newTestRedisCounter(t)
+	defer s.Close()
+	cacheServer := NewCacheServer("", c)
+	testServer := httptest.NewServer(cacheServer.server.Handler)
+	defer testServer.Close()
+
+	key := "test_key"
+	incrBy := uint(5)
+	expire := 1 * time.Second
+	maxBlock := uint64(15)
+
+	c.Incr(context.Background(), key, incrBy, maxBlock, expire)
+	c.Incr(context.Background(), key, incrBy, maxBlock, expire)
+
+	// sleep required because newTestRedisCounter returns an async counter
+	time.Sleep(100 * time.Millisecond)
+
+	req, err := http.NewRequest("DELETE", testServer.URL+"/v0/counters", nil)
+	if err != nil {
+		t.Fatalf("could not create request: %v", err)
+	}
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("error from cache server: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("unexpected status code from cache server: %v", resp.StatusCode)
+	}
+
+	c.cache.RLock()
+	defer c.cache.RUnlock()
+	_, ok := c.cache.m[key]
+	if ok {
+		t.Fatalf("key exists in cache when it should not")
+	}
+}

--- a/pkg/guardian/cache_server.go
+++ b/pkg/guardian/cache_server.go
@@ -1,0 +1,50 @@
+package guardian
+
+import (
+	"context"
+	"net/http"
+)
+
+// CacheServer is an HTTP server for manipulating Guardian's In Memory Cache.
+// Useful for e2e testing where the Guardian server might be running in a separate process.
+type CacheServer struct {
+	rc     *RedisCounter
+	server *http.Server
+}
+
+func NewCacheServer(address string, rc *RedisCounter) *CacheServer {
+	mux := http.NewServeMux()
+	server := &http.Server{
+		Addr:    address,
+		Handler: mux,
+	}
+	cs := &CacheServer{
+		server: server,
+		rc:     rc,
+	}
+	mux.HandleFunc("/v0/counters", cs.DeleteCounters)
+	return cs
+}
+
+func (cs *CacheServer) Run(stop <-chan struct{}) error {
+	var err error
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- cs.server.ListenAndServe()
+	}()
+	select {
+	case <-stop:
+	case serverError := <-errChan:
+		err = serverError
+	}
+	cs.server.Shutdown(context.TODO())
+	return err
+}
+
+func (cs *CacheServer) DeleteCounters(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "method not accepted", 405)
+	}
+	cs.rc.removeAll()
+	w.WriteHeader(200)
+}

--- a/pkg/guardian/redis_counter.go
+++ b/pkg/guardian/redis_counter.go
@@ -107,6 +107,12 @@ func (rs *RedisCounter) pruneCache(olderThan time.Time) {
 	}
 }
 
+func (rs *RedisCounter) removeAll() {
+	rs.cache.Lock()
+	defer rs.cache.Unlock()
+	rs.cache.m = make(map[string]item)
+}
+
 func (rs *RedisCounter) doIncr(context context.Context, key string, incrBy uint, expireIn time.Duration) (uint64, error) {
 	start := time.Now().UTC()
 	var err error


### PR DESCRIPTION
* In our e2e tests, the Guardian server runs in a separate container. However, we need a way to communicate with Guardian in order to remove all entries from the internal counter cache. To do this, i created a small http server which accepts requests for deleting entries from the counter. While using pseudo random ip addresses should remove the need for deleting all entries in the counter in most cases, there are still some tests where we hard code some ip addresses in, which could lead to issues. 