### PR TITLE
Check usage of ports to be forwarded before running E2E test

### DIFF
--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+for port in 8080 8082 3000 6060 5678 6379; do
+   if lsof -i ":${port}"; then
+      echo "required port ${port} is already in use; terminating"
+      exit 1
+   fi
+done
+
 echo "Starting async guardian..."
 docker-compose -f e2e/docker-compose-async.yml up -d --build --force-recreate > /dev/null 2>&1
 [[ $? -gt 0 ]] && exit 1


### PR DESCRIPTION
I ran into a frustrating issue where Docker Compose silently failed to establish a port forward due to an existing Redis instance already running on that port, causing hard to debug test failures. I spent some time working on an improved test setup based on Acyl, but after overcoming several hurdles got stuck on replicating the Envoy configuration, which failed with deprecation errors when running via DQA. Envoy is complex enough that we have decided to wait on putting any more hours into this until we make a longer-term plan for rate limiting.

For now, I've made this PR, which uses `lsof` to check if any of the ports used in the Docker Compose config are already open before running the tests.